### PR TITLE
very important oneliner fix

### DIFF
--- a/src/scrollLayer.cpp
+++ b/src/scrollLayer.cpp
@@ -11,7 +11,7 @@ class $modify(scroll, GJGarageLayer) {
         CCSprite* m_cursorCust1 = nullptr;
         CCSprite* m_cursorCust2 = nullptr;
 
-        AxisLayout* m_layout = nullptr;
+        Ref<AxisLayout> m_layout = nullptr;
 
         CCMenu* m_iconMenu = nullptr;
         CCArray* m_iconArray = nullptr;


### PR DESCRIPTION
you could ask @hiimjasmine00 about the exact specifics of this one liner fix; i don't know as much about the ins and outs of geode compared to her.

either way, this oneliner fix is necessary because pressing the category buttons in the icon kit/garage using anything besides physical mouse click can cause a crash